### PR TITLE
Draft: English IT Support in Tokyo — for review

### DIFF
--- a/app/services/english-it-support-tokyo/page.tsx
+++ b/app/services/english-it-support-tokyo/page.tsx
@@ -1,0 +1,77 @@
+import { Metadata } from "next"
+import Link from "next/link"
+
+// DRAFT — targeting "english it support tokyo" (SurferSEO Content Editor draft 16358978, workspace akrin).
+// Do not merge without review. Surfer guidelines: 1.5K–1.7K words, 23+ headings, 32+ paragraphs.
+
+export const metadata: Metadata = {
+title: "English IT Support in Tokyo | Bilingual Helpdesk & On-Site | AKRIN",
+description: "English-speaking IT support in Tokyo for international businesses. Bilingual helpdesk, remote and on-site technical support, infrastructure and security services across Japan.",
+alternates: {
+canonical: "https://akrin.jp/services/english-it-support-tokyo"
+},
+openGraph: {
+title: "English IT Support in Tokyo | Bilingual Helpdesk & On-Site | AKRIN",
+description: "English-speaking IT support in Tokyo for international businesses. Bilingual helpdesk, remote and on-site technical support, infrastructure and security services across Japan.",
+url: "https://akrin.jp/services/english-it-support-tokyo",
+siteName: "Akrin IT Solutions",
+locale: "en_US",
+type: "website"
+}
+}
+
+export default function EnglishITSupportTokyoPage() {
+return (
+<main className="mx-auto max-w-4xl px-4 py-16">
+<h1 className="text-4xl font-bold mb-6">English IT Support in Tokyo for International Businesses</h1>
+<p className="mb-4">Finding reliable English IT support in Tokyo is one of the first challenges international companies face when they open or grow an office in Japan. Most local IT vendors work primarily in Japanese, while global helpdesks rarely understand the systems, vendors, and business practices used by Japanese companies. AKRIN closes that gap with bilingual technical support delivered by engineers who work comfortably in both English and Japanese.</p>
+<p className="mb-4">This page explains the English-speaking IT support services we provide in the Tokyo area, who they are designed for, and how onboarding works. If you simply want to talk to an engineer, you can <Link href="/contact-form" className="underline">book a free consultation</Link> at any time.</p>
+<h2 className="text-2xl font-semibold mt-10 mb-4">Why English-speaking IT support matters in Japan</h2>
+<p className="mb-4">Foreign companies in Japan usually operate with a small in-house IT presence, or none at all. Global headquarters expects reporting and security practices in English, while local staff, vendors, and internet providers expect Japanese. When something breaks, end users lose hours to translation instead of troubleshooting.</p>
+<p className="mb-4">A bilingual IT partner removes that friction. Your team gets clear answers in English, while our engineers coordinate with Japanese carriers, hardware suppliers, and building management in their own language. The result is faster resolution times, cleaner documentation, and far less risk of misunderstanding between your global and local teams.</p>
+<h2 className="text-2xl font-semibold mt-10 mb-4">Our English IT support services in Tokyo</h2>
+<h3 className="text-xl font-semibold mt-6 mb-3">Bilingual helpdesk and remote support</h3>
+<p className="mb-4">Unlimited helpdesk support for end users, delivered in English or Japanese. Our support engineers resolve day-to-day problems with laptops, mobile devices, printers, Microsoft 365, Google Workspace, and business applications through fast remote support sessions.</p>
+<h3 className="text-xl font-semibold mt-6 mb-3">On-site support across the Tokyo area</h3>
+<p className="mb-4">When remote support is not enough, we dispatch engineers on site — to your office, data center, warehouse, or company events. We cover central Tokyo and the greater Kanto region, with nationwide coverage across Japan through our field network.</p>
+<h3 className="text-xl font-semibold mt-6 mb-3">IT infrastructure, network, and servers</h3>
+<p className="mb-4">Design, build, and management of office infrastructure: wired and wireless networks, firewalls, servers, cloud environments, and identity management. We also handle office moves and new office setup projects end to end. See our <Link href="/services/it-managed-services" className="underline">managed IT services</Link> for the full scope.</p>
+<h3 className="text-xl font-semibold mt-6 mb-3">Cybersecurity and compliance</h3>
+<p className="mb-4">Endpoint protection, email security, vulnerability management, and security monitoring aligned with global standards. Our team helps you meet both headquarters requirements and Japanese regulations. Learn more about our <Link href="/services/it-security" className="underline">IT security services</Link>.</p>
+<h3 className="text-xl font-semibold mt-6 mb-3">IT asset disposition (ITAD)</h3>
+<p className="mb-4">Secure, certified disposal of retired hardware with data sanitization reports accepted by global auditors. Details are on our <Link href="/services/itad-japan-apac-us" className="underline">ITAD Japan page</Link>.</p>
+<h2 className="text-2xl font-semibold mt-10 mb-4">Who we help</h2>
+<ul className="list-disc pl-6 mb-4 space-y-2">
+<li>Foreign companies opening or operating a Tokyo office that need a dependable local IT department without hiring in house.</li>
+<li>Japanese companies working with global partners that need English documentation, reporting, and collaboration with overseas teams.</li>
+<li>Startups and growing teams that need enterprise-grade infrastructure, security, and support without enterprise overhead.</li>
+</ul>
+<h2 className="text-2xl font-semibold mt-10 mb-4">How onboarding works</h2>
+<ol className="list-decimal pl-6 mb-4 space-y-2">
+<li>Free consultation — we discuss your environment, pain points, and goals in English or Japanese.</li>
+<li>Assessment — our engineers audit your infrastructure, accounts, licenses, and security posture.</li>
+<li>Proposal — a clear scope with fixed monthly pricing and response-time commitments.</li>
+<li>Transition — we document everything, take over vendor contracts where needed, and introduce your team to the helpdesk.</li>
+</ol>
+<h2 className="text-2xl font-semibold mt-10 mb-4">Why companies choose AKRIN</h2>
+<ul className="list-disc pl-6 mb-4 space-y-2">
+<li>Truly bilingual engineers — technical support in fluent English and native Japanese, not a translation layer.</li>
+<li>24/7 monitoring and response backed by clear SLAs.</li>
+<li>One partner for helpdesk, infrastructure, security, and projects — fewer contracts to manage.</li>
+<li>Experience with both global tools and the systems Japanese companies rely on.</li>
+</ul>
+<h2 className="text-2xl font-semibold mt-10 mb-4">Frequently asked questions</h2>
+<h3 className="text-xl font-semibold mt-6 mb-2">Do you support both English and Japanese end users?</h3>
+<p className="mb-4">Yes. Every ticket can be handled in either language, and documentation is delivered bilingually on request.</p>
+<h3 className="text-xl font-semibold mt-6 mb-2">Can you work with our global headquarters and tools?</h3>
+<p className="mb-4">Yes. We regularly integrate with global IT departments, follow group security policies, and report in English to overseas management.</p>
+<h3 className="text-xl font-semibold mt-6 mb-2">Do you cover locations outside Tokyo?</h3>
+<p className="mb-4">Yes. On-site support is available across Japan, and remote support has no location limits.</p>
+<h3 className="text-xl font-semibold mt-6 mb-2">Can you replace our current IT vendor?</h3>
+<p className="mb-4">Yes. We manage the transition, including documentation handover and coordination with the outgoing vendor, so end users see no interruption.</p>
+<h2 className="text-2xl font-semibold mt-10 mb-4">Talk to an engineer</h2>
+<p className="mb-6">Tell us about your environment and we will come back with a clear plan and pricing. No obligation, in English or Japanese.</p>
+<Link href="/contact-form" className="inline-block rounded-md bg-purple-600 px-6 py-3 text-white font-semibold">Book a free consultation</Link>
+</main>
+)
+}


### PR DESCRIPTION
New SEO service page targeting "english it support tokyo" (from GSC: several English IT support queries impressing at positions 13-52 with no dedicated landing page).

- SurferSEO Content Editor brief: https://app.surferseo.com/workspace/1300337-akrin/drafts/16358978 (guidelines: 1.5K-1.7K words, 23+ headings). Draft currently ~1,100 words - expand and restyle with site components before publishing.
- - Internal links to /services/it-managed-services, /services/it-security, /services/itad-japan-apac-us, /contact-form.
- - Styling is plain Tailwind - needs the site's design system components and a JA version.
DO NOT MERGE without review. Created by the weekly SEO automation.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a bilingual landing page for English IT support services in Tokyo.
  * Included service details, target audiences, onboarding steps, FAQs, and reasons to choose the provider.
  * Added SEO metadata and social sharing information.
  * Added a call-to-action linking visitors to the contact form.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->