### PR TITLE
Draft: English IT Support Tokyo blog post (SurferSEO brief) — for review

### DIFF
--- a/content/drafts/english-it-support-tokyo.md
+++ b/content/drafts/english-it-support-tokyo.md
@@ -1,0 +1,111 @@
+# DRAFT — English IT Support Tokyo (for review, do not publish as-is)
+
+> **Target keyword:** english it support tokyo (SurferSEO Content Editor draft #16361188, workspace "akrin")
+> **Surfer guidelines:** 1.6K–1.9K words, terms covered: bilingual helpdesk, support engineer, on-site, remote, 外資系, APPI, ISO 27001, managed IT services, 24/7 IT support, cloud migration, etc.
+> **Proposed slug:** `english-it-support-tokyo`
+> **Proposed title tag:** English IT Support Tokyo | Bilingual Helpdesk & MSP | AKRIN
+> **Proposed meta description:** English-speaking IT support in Tokyo for international companies. Bilingual EN/JA helpdesk, on-site engineers, 24/7 monitoring, cloud & security. Book a free consultation.
+> **Excerpt:** Finding reliable English IT support in Tokyo is one of the biggest operational hurdles for international companies in Japan. Here is how a bilingual helpdesk, on-site support engineers, and 24/7 managed services keep your Tokyo office running.
+>
+> **How to publish:** add as a new entry in `lib/blog-data.ts` (blogPostsEN) or as a Sanity post, then add the slug to the sitemap. Internal links point to existing pages.
+
+---
+
+# English IT Support in Tokyo: Bilingual Helpdesk and Managed IT Services for International Companies
+
+If your company operates in Tokyo and your team works in English, you have probably discovered how hard it is to find IT support that communicates clearly in both English and Japanese. AKRIN K.K. provides English IT support in Tokyo — a bilingual helpdesk, on-site support engineers, and 24/7 managed IT services — built specifically for international companies, 外資系 (foreign-affiliated) firms, and expat-led businesses across the Tokyo area.
+
+This page explains what English-speaking IT support in Tokyo includes, how our support contracts work, what it costs, and how to decide whether a bilingual managed services provider (MSP) is the right fit for your business.
+
+## Why international companies in Tokyo need bilingual IT support
+
+Tokyo is home to thousands of multinational corporations, regional headquarters, and startups founded by English speakers. Most local IT vendors, however, operate exclusively in Japanese: their contracts, documentation, ticketing systems, and support engineers all assume Japanese-language communication.
+
+That gap creates real operational problems:
+
+- **Slow incident resolution.** When users can't describe problems to the helpdesk in their own language, minor incidents drag on for days.
+- **Communication breakdowns with global IT.** Your headquarters' IT department needs reporting and documentation in English, while local vendors deliver everything in Japanese.
+- **Compliance risk.** Meeting both Japanese regulations (APPI — the Act on the Protection of Personal Information) and international standards such as ISO 27001 or GDPR requires a provider who understands both worlds.
+- **Hiring pressure.** Recruiting an in-house bilingual support engineer in Tokyo is expensive and slow; retaining one is harder still.
+
+A bilingual IT support provider bridges local staff and global IT managers, so your Tokyo office stops being the exception in your worldwide infrastructure.
+
+## Our English IT support services in Tokyo
+
+AKRIN delivers complete IT operations for companies from 10 to 500+ users. Everything is available in English and Japanese.
+
+### Bilingual helpdesk (EN/JA)
+
+Unlimited remote support for your users via phone, email, and chat. Tickets are handled by bilingual support engineers, so English speakers and Japanese staff get the same quality of service. Documentation and reporting are delivered in English by default.
+
+### On-site support engineers
+
+When remote troubleshooting isn't enough, our engineers come to your office anywhere in the Tokyo area — typically same day or next business day. For larger clients we can provide embedded engineers who work on site at your office on scheduled days.
+
+### 24/7 monitoring and managed IT services
+
+Proactive monitoring of your servers, network, and cloud infrastructure with automated alerting and incident response. Our managed IT services cover patching, backup, asset management, and vendor management under a flat monthly contract — so budgeting is predictable and there are no surprise invoices.
+
+### Cloud and infrastructure projects
+
+Cloud migration to Microsoft 365, Azure, AWS, or Google Cloud with bilingual project management. We also design and deploy office networks, Wi-Fi, and server rooms — including full IT setup for office relocations and new office openings in Tokyo.
+
+### Security and compliance
+
+Endpoint protection (EDR), email security, vulnerability management, and security monitoring aligned with ISO 27001 practices and APPI requirements. We help international companies pass global security audits without disrupting local operations.
+
+## Who we help
+
+- **外資系 / foreign-affiliated companies** that need a local IT partner who reports to global IT in English.
+- **Expat-led businesses and startups** that want enterprise-grade IT without hiring an internal team.
+- **Japanese companies going global** that need documentation, tooling, and support practices that work in English.
+- **Regional offices** whose headquarters require consistent security standards across every site.
+
+## How our support contracts work
+
+Most clients choose a flat-fee monthly contract based on user count and coverage hours. A typical engagement includes:
+
+1. **Onboarding and documentation.** We audit your current environment, document your infrastructure in English, and set up monitoring and the helpdesk.
+2. **Day-to-day support.** Users contact the bilingual helpdesk directly; incidents and requests are tracked with clear SLAs.
+3. **Monthly reporting.** You receive English-language reports covering tickets, incidents, asset changes, and recommendations.
+
+Entry-level managed support in Tokyo typically starts from around ¥80,000 per month for small teams, scaling with users, sites, and coverage hours. We'll give you a clear quote after a short assessment — no obligation.
+
+## Why companies choose AKRIN
+
+- **Truly bilingual.** Native-level English and Japanese across the helpdesk, engineering, and account management — not a translation layer.
+- **One partner for everything.** Helpdesk, infrastructure, cloud, security, and relocations under one contract.
+- **International standards, local execution.** ISO 27001-aligned practices, APPI compliance, and experience with global audits.
+- **Tokyo-based, Japan-wide.** On-site support in the Tokyo area with remote and project coverage across Japan and APAC.
+
+## Frequently asked questions
+
+### Do you support both English and Japanese users?
+
+Yes. Our helpdesk and engineers are bilingual, so mixed teams get one support experience. Tickets can be raised in either language.
+
+### Can you work with our headquarters' IT team overseas?
+
+Absolutely — this is one of the most common ways we work. We act as the local hands and eyes for your global IT department, with reporting, documentation, and change management in English.
+
+### Do you offer one-time projects, or only monthly contracts?
+
+Both. Office relocations, cloud migrations, network builds, and audits are available as fixed-scope projects, and many project clients later move to a managed support contract.
+
+### How fast is on-site response in Tokyo?
+
+Remote response is typically within minutes during business hours. On-site response in central Tokyo is usually same day or next business day, depending on your contract's SLA.
+
+### Can you take over from our current IT vendor?
+
+Yes. We handle vendor transitions regularly, including environments with little or no documentation. We audit, document in English, and take over operations with minimal disruption.
+
+### Do you support offices outside Tokyo?
+
+Yes — remote support covers all of Japan, and we dispatch engineers or use trusted partners for on-site work nationwide and across APAC.
+
+## Get English IT support in Tokyo
+
+Stop translating your IT problems. Talk to a bilingual engineer, get a clear assessment of your environment, and see what a flat-fee support contract would look like for your team.
+
+**[Book a free consultation](/contact-form)** — or explore our [managed IT services](/services/it-managed-services) and [IT security services](/services/it-security).


### PR DESCRIPTION
Weekly SEO run (automated): new lead-gen content draft targeting "english it support tokyo" (GSC shows "it support in tokyo" and related queries with impressions but weak positions).

- SurferSEO Content Editor brief created in workspace "akrin" (draft 16361188): 1.6K-1.9K words, terms & FAQ structure follow the brief
- - Draft is in content/drafts/english-it-support-tokyo.md with proposed slug, title tag, meta description and excerpt at the top
- - To publish: add as a blogPostsEN entry in lib/blog-data.ts (or Sanity), internal links already point to /contact-form, /services/it-managed-services, /services/it-security
- - DO NOT merge as-is; review pricing claim and service details first
This PR was intentionally NOT merged - awaiting your review.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Content**
  * Added a draft “English IT Support Tokyo” page for SEO and content review.
  * Includes bilingual IT support services, compliance information, pricing guidance, FAQs, contract details, and consultation links.
  * Added metadata such as the target keyword, page title, description, excerpt, and publishing instructions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->